### PR TITLE
Add default pagantis AWS region

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,6 +21,8 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
+config :ex_aws, :sns, region: "eu-west-1"
+
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment
 # by uncommenting the line below and defining dev.exs, test.exs and such.

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,7 +21,7 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
-config :ex_aws, :sns, region: "eu-west-1"
+config :ex_aws, :sns, region: System.get_env("AWS_DEFAULT_REGION")
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/lib/events/README.md
+++ b/lib/events/README.md
@@ -6,12 +6,13 @@ Besides publishing this package verifies structure and definitions according to 
 
 ## Config
 
-The next env vars need to be set to work with AWS and this library
+The next env vars need to be set to work with AWS and this library:
 
 ```bash
 AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=bar
 AWS_SNS_TOPIC="arn:aws:sns:us-west-2:123456789012:topic2"
+AWS_DEFAULT_REGION="us-east-1"
 ```
 
 To use, add to your `config.ex`:


### PR DESCRIPTION
#### :tophat: Problem
Pagantis AWS default region is eu-west-1

#### :pushpin: Solution
Override default ex_aws region.

#### :ghost: GIF
![giphy](https://user-images.githubusercontent.com/2565201/56660253-6e6d4980-669f-11e9-8db6-ac6c3dedcb8c.gif)

