### PR TITLE
PAYM-2224 Switch to uuid5

### DIFF
--- a/lib/events/README.md
+++ b/lib/events/README.md
@@ -39,10 +39,11 @@ config :ex_aws, :sns,
 
 ## Usage
 ```elixir
-Event.publish(%Event{name: "NAME_EXAMPLE", payload: %{key: "value"}, version: "1.0.0"}
+Event.publish(%Event{name: "NAME_EXAMPLE", event_id_seed: "f367d382-6452-435c-ad83-3477bd530349", payload: %{key: "value"}, version: "1.0.0"}
 ```
 Where:
 * `name` - obligatory, string, contains at least one `_`
+* `event_id_seed` - obligatory, string in UUID format, which will be used together with `name` as a seed for event_id generation. If both values will be the same - event will be updated in datalake.
 * `payload` - optional, map
 * `version` - optional, string, `\d+.\d+.\d+` format
 

--- a/lib/events/README.md
+++ b/lib/events/README.md
@@ -43,7 +43,8 @@ Event.publish(%Event{name: "NAME_EXAMPLE", event_id_seed: "f367d382-6452-435c-ad
 ```
 Where:
 * `name` - obligatory, string, contains at least one `_`
-* `event_id_seed` - obligatory, string in UUID format, which will be used together with `name` as a seed for event_id generation. If both values will be the same - event will be updated in datalake.
+* `event_id_seed` - obligatory, string in UUID format, which will be used together with `name` and `version` as a seed for event_id generation. 
+If all values will be the same -> event_id will be the same -> event will be updated in S3.
 * `payload` - optional, map
 * `version` - optional, string, `\d+.\d+.\d+` format
 

--- a/lib/events/adapters/aws_sns.ex
+++ b/lib/events/adapters/aws_sns.ex
@@ -38,7 +38,7 @@ defmodule ElixirTools.Events.Adapters.AwsSns do
     group = opts[:group] || Map.fetch!(config, :group)
 
     %{
-      id: UUID.uuid4(),
+      id: UUID.uuid5(event.event_id_seed, event.name),
       action: String.upcase(event.name),
       group: group,
       occurred_at: Timex.format!(Timex.now(), "{ISO:Extended:Z}"),

--- a/lib/events/adapters/aws_sns.ex
+++ b/lib/events/adapters/aws_sns.ex
@@ -36,9 +36,10 @@ defmodule ElixirTools.Events.Adapters.AwsSns do
   defp add_envelope(event, opts) do
     config = Application.get_env(:pagantis_elixir_tools, ElixirTools.Events)[:adapter_config]
     group = opts[:group] || Map.fetch!(config, :group)
+    id = UUID.uuid5(event.event_id_seed, event.name <> event.version)
 
     %{
-      id: UUID.uuid5(event.event_id_seed, event.name),
+      id: id,
       action: String.upcase(event.name),
       group: group,
       occurred_at: Timex.format!(Timex.now(), "{ISO:Extended:Z}"),

--- a/lib/events/event.ex
+++ b/lib/events/event.ex
@@ -7,13 +7,14 @@ defmodule ElixirTools.Events.Event do
   @type t :: %Event{
           name: String.t(),
           version: String.t(),
-          payload: map
+          payload: map,
+          event_id_seed: Ecto.UUID.t()
         }
 
   @typep return :: :ok | {:error, reason :: String.t()}
 
-  @enforce_keys ~w(name)a
-  defstruct [:name, payload: %{}, version: "1.0.0"]
+  @enforce_keys ~w(name event_id_seed)a
+  defstruct [:name, :event_id_seed, payload: %{}, version: "1.0.0"]
 
   @spec publish(t, module | nil) :: return
   def publish(event, adapter \\ nil) do

--- a/lib/events/event.ex
+++ b/lib/events/event.ex
@@ -55,9 +55,8 @@ defmodule ElixirTools.Events.Event do
 
   @spec validate_event_id_seed(any) :: return
   defp validate_event_id_seed(event_id_seed) do
-    with {:ok, _} <- UUID.info(event_id_seed) do
-      :ok
-    else
+    case UUID.info(event_id_seed) do
+      {:ok, _} -> :ok
       _ -> {:error, "Expected a UUID string as event_id_seed, but got #{inspect(event_id_seed)}"}
     end
   end

--- a/lib/events/event.ex
+++ b/lib/events/event.ex
@@ -1,6 +1,8 @@
 defmodule ElixirTools.Events.Event do
   @moduledoc """
-  A structure for working with events
+  A structure for working with events.
+  `event_id_seed` is used for `event_id` generation(UUID5) together with `name` & `version`.
+  So if all values are the same event will be updated.
   """
   alias __MODULE__
 

--- a/lib/events/event.ex
+++ b/lib/events/event.ex
@@ -33,6 +33,7 @@ defmodule ElixirTools.Events.Event do
   def validate(event) do
     with :ok <- validate_name(event.name),
          :ok <- validate_payload(event.payload),
+         :ok <- validate_event_id_seed(event.event_id_seed),
          :ok <- validate_version(event.version) do
       :ok
     end
@@ -49,6 +50,15 @@ defmodule ElixirTools.Events.Event do
 
       true ->
         :ok
+    end
+  end
+
+  @spec validate_event_id_seed(any) :: return
+  defp validate_event_id_seed(event_id_seed) do
+    with {:ok, _} <- UUID.info(event_id_seed) do
+      :ok
+    else
+      _ -> {:error, "Expected a UUID string as event_id_seed, but got #{inspect(event_id_seed)}"}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ElixirTools.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.7.0"
   @description "Tools used in pagantis for making developing easier"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ElixirTools.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.7.0"
   @description "Tools used in pagantis for making developing easier"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ElixirTools.MixProject do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.8.0"
   @description "Tools used in pagantis for making developing easier"
 
   def project do

--- a/test/events/adapters/aws_sns_test.exs
+++ b/test/events/adapters/aws_sns_test.exs
@@ -37,7 +37,10 @@ defmodule ElixirTools.Events.Adapters.AwsSnsTest do
   end
 
   setup do
-    valid_event = %Event{name: "TEST_EVENT"}
+    valid_event = %Event{
+      name: "TEST_EVENT",
+      event_id_seed: "016c25fd-70e0-56fe-9d1a-56e80fa20b82"
+    }
 
     %{valid_event: valid_event}
   end

--- a/test/events/event_test.exs
+++ b/test/events/event_test.exs
@@ -91,5 +91,12 @@ defmodule ElixirTools.Events.EventTest do
                  Event.publish(event, FakeAdapterSuccess)
       end)
     end
+
+    test "returns error when event_id_seed is not a UUID string", context do
+      event = %{context.valid_event | event_id_seed: "not uuid string"}
+
+      assert {:error, "Expected a UUID string as event_id_seed, but got \"not uuid string\""} ==
+               Event.publish(event, FakeAdapterSuccess)
+    end
   end
 end

--- a/test/events/event_test.exs
+++ b/test/events/event_test.exs
@@ -17,7 +17,8 @@ defmodule ElixirTools.Events.EventTest do
 
   setup do
     valid_event = %Event{
-      name: "TEST_EVENT"
+      name: "TEST_EVENT",
+      event_id_seed: "016c25fd-70e0-56fe-9d1a-56e80fa20b82"
     }
 
     %{valid_event: valid_event}


### PR DESCRIPTION
#### :tophat: Problem
We can't update events in S3 by ourselves, we need to ask data people to remove old ones every time

#### :pushpin: Solution
We can switch to UUID5 -> event_id will be reproducible -> we can send same events for the same entities with the same event_id -> by this we will create a new version in S3 == update wrong values == we're indepent with event updates

#### :ghost: GIF
 ![](https://media.giphy.com/media/ZPyywQXc8RQpa/giphy.gif)
