### PR TITLE
Renamed 'mayor' to 'major'

### DIFF
--- a/lib/events/event.ex
+++ b/lib/events/event.ex
@@ -58,15 +58,15 @@ defmodule ElixirTools.Events.Event do
   @spec validate_version(any) :: return
   defp validate_version(version) do
     with {:is_string, true} <- {:is_string, is_binary(version)},
-         {:split, [mayor, minor, fix]} <- {:split, String.split(version, ".")},
-         {:parse_mayor, {_, ""}} <- {:parse_mayor, Integer.parse(mayor)},
+         {:split, [major, minor, fix]} <- {:split, String.split(version, ".")},
+         {:parse_major, {_, ""}} <- {:parse_major, Integer.parse(major)},
          {:parse_minor, {_, ""}} <- {:parse_minor, Integer.parse(minor)},
          {:parse_fix, {_, ""}} <- {:parse_fix, Integer.parse(fix)} do
       :ok
     else
       {:is_string, false} -> {:error, "Expected a string with a version"}
       {:split, _} -> {:error, "Expected version with 3 dots, but received #{version}"}
-      {:parse_mayor, _} -> {:error, "Expected a number for the mayor, but received #{version}"}
+      {:parse_major, _} -> {:error, "Expected a number for the major, but received #{version}"}
       {:parse_minor, _} -> {:error, "Expected a number for the minor, but received #{version}"}
       {:parse_fix, _} -> {:error, "Expected a number for the fix, but received #{version}"}
     end

--- a/test/events/event_test.exs
+++ b/test/events/event_test.exs
@@ -40,17 +40,17 @@ defmodule ElixirTools.Events.EventTest do
                Event.publish(event, FakeAdapterSuccess)
     end
 
-    test "returns error when version is not having mayor.minor.fix format", context do
+    test "returns error when version is not having major.minor.fix format", context do
       event = %{context.valid_event | version: "1.1"}
 
       assert {:error, "Expected version with 3 dots, but received 1.1"} ==
                Event.publish(event, FakeAdapterSuccess)
     end
 
-    test "returns error when version mayor is not an integer", context do
+    test "returns error when version major is not an integer", context do
       event = %{context.valid_event | version: "1a.1.1"}
 
-      assert {:error, "Expected a number for the mayor, but received 1a.1.1"} ==
+      assert {:error, "Expected a number for the major, but received 1a.1.1"} ==
                Event.publish(event, FakeAdapterSuccess)
     end
 


### PR DESCRIPTION
#### :tophat: Problem
In ElixirTools.Events.Event, we are referring to the MAJOR version as `mayor`.

Issue: https://github.com/digitalorigin/pg-elixir-tools/issues/26

#### :pushpin: Solution
Fix the typos in `Event` and `EventTest` modules

#### :ghost: GIF
 ![](https://media.giphy.com/media/MUEq7KfQvNolX9YujV/giphy.gif)
