### PR TITLE
Add event_id_seed_optional

### DIFF
--- a/lib/events/README.md
+++ b/lib/events/README.md
@@ -45,7 +45,7 @@ Where:
 * `name` - obligatory, string, contains at least one `_`
 * `event_id_seed` - obligatory, string in UUID format, which will be used together with `name`, `version` & `event_id_seed_optional` as a seed for event_id generation. 
 If all values will be the same -> event_id will be the same -> event will be updated in S3.
-* `event_id_seed_optional` - string, optional part used for event_id generation
+* `event_id_seed_optional` - string, optional part used for event_id generation. By default - ""(empty string)
 * `payload` - optional, map
 * `version` - optional, string, `\d+.\d+.\d+` format
 

--- a/lib/events/README.md
+++ b/lib/events/README.md
@@ -43,8 +43,9 @@ Event.publish(%Event{name: "NAME_EXAMPLE", event_id_seed: "f367d382-6452-435c-ad
 ```
 Where:
 * `name` - obligatory, string, contains at least one `_`
-* `event_id_seed` - obligatory, string in UUID format, which will be used together with `name` and `version` as a seed for event_id generation. 
+* `event_id_seed` - obligatory, string in UUID format, which will be used together with `name`, `version` & `event_id_seed_optional` as a seed for event_id generation. 
 If all values will be the same -> event_id will be the same -> event will be updated in S3.
+* `event_id_seed_optional` - string, optional part used for event_id generation
 * `payload` - optional, map
 * `version` - optional, string, `\d+.\d+.\d+` format
 

--- a/lib/events/adapters/aws_sns.ex
+++ b/lib/events/adapters/aws_sns.ex
@@ -12,6 +12,7 @@ defmodule ElixirTools.Events.Adapters.AwsSns do
   @typep publish_opt ::
            {:aws_module, module}
            | {:sns_module, module}
+           | {:uuid_module, module}
            | {:group, String.t()}
            | {:topic, String.t()}
 
@@ -34,9 +35,13 @@ defmodule ElixirTools.Events.Adapters.AwsSns do
 
   @spec add_envelope(Event.t(), [publish_opt]) :: map
   defp add_envelope(event, opts) do
+    uuid_module = opts[:uuid_module] || UUID
+
     config = Application.get_env(:pagantis_elixir_tools, ElixirTools.Events)[:adapter_config]
     group = opts[:group] || Map.fetch!(config, :group)
-    id = UUID.uuid5(event.event_id_seed, event.name <> event.version)
+
+    uuid_seed_2 = "#{event.name}-#{event.version}-#{event.event_id_seed_optional}"
+    id = uuid_module.uuid5(event.event_id_seed, uuid_seed_2)
 
     %{
       id: id,

--- a/lib/events/event.ex
+++ b/lib/events/event.ex
@@ -10,13 +10,14 @@ defmodule ElixirTools.Events.Event do
           name: String.t(),
           version: String.t(),
           payload: map,
-          event_id_seed: Ecto.UUID.t()
+          event_id_seed: Ecto.UUID.t(),
+          event_id_seed_optional: String.t()
         }
 
   @typep return :: :ok | {:error, reason :: String.t()}
 
   @enforce_keys ~w(name event_id_seed)a
-  defstruct [:name, :event_id_seed, payload: %{}, version: "1.0.0"]
+  defstruct [:name, :event_id_seed, payload: %{}, version: "1.0.0", event_id_seed_optional: ""]
 
   @spec publish(t, module | nil) :: return
   def publish(event, adapter \\ nil) do
@@ -36,10 +37,17 @@ defmodule ElixirTools.Events.Event do
     with :ok <- validate_name(event.name),
          :ok <- validate_payload(event.payload),
          :ok <- validate_event_id_seed(event.event_id_seed),
+         :ok <- validate_event_id_seed_optional(event.event_id_seed_optional),
          :ok <- validate_version(event.version) do
       :ok
     end
   end
+
+  @spec validate_event_id_seed_optional(any) :: return
+  defp validate_event_id_seed_optional(value) when is_binary(value), do: :ok
+
+  defp validate_event_id_seed_optional(value),
+    do: {:error, "Expected a string as event_id_seed_optional, but got #{inspect(value)}"}
 
   @spec validate_name(any) :: return
   defp validate_name(name) do

--- a/test/events/event_test.exs
+++ b/test/events/event_test.exs
@@ -98,5 +98,12 @@ defmodule ElixirTools.Events.EventTest do
       assert {:error, "Expected a UUID string as event_id_seed, but got \"not uuid string\""} ==
                Event.publish(event, FakeAdapterSuccess)
     end
+
+    test "returns error when event_id_seed_optional is not a string", context do
+      event = %{context.valid_event | event_id_seed_optional: 123}
+
+      assert {:error, "Expected a string as event_id_seed_optional, but got 123"} ==
+               Event.publish(event, FakeAdapterSuccess)
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: Problem
Apparently, we found in https://github.com/digitalorigin/pg-payments/pull/991 that just `object_id + event_name + version` is not enough sometimes. 

#### :pushpin: Solution
Add one optional part `event_id_seed_optional`. It will be empty for most of the cases. In pg-payments only `CHARGE_CONFIRMED` will use it.

#### :ghost: GIF
 ![](https://media.giphy.com/media/xk1tFYYbRpT8c/giphy.gif)
