### PR TITLE
Add occurred_at optional field to Event

### DIFF
--- a/lib/events/adapters/aws_sns.ex
+++ b/lib/events/adapters/aws_sns.ex
@@ -43,11 +43,14 @@ defmodule ElixirTools.Events.Adapters.AwsSns do
     uuid_seed_2 = "#{event.name}-#{event.version}-#{event.event_id_seed_optional}"
     id = uuid_module.uuid5(event.event_id_seed, uuid_seed_2)
 
+    occurred_at = event.occurred_at || Timex.now()
+    occurred_at = Timex.format!(occurred_at, "{ISO:Extended:Z}")
+
     %{
       id: id,
       action: String.upcase(event.name),
       group: group,
-      occurred_at: Timex.format!(Timex.now(), "{ISO:Extended:Z}"),
+      occurred_at: occurred_at,
       version: event.version,
       payload: event.payload
     }

--- a/lib/events/adapters/aws_sns.ex
+++ b/lib/events/adapters/aws_sns.ex
@@ -46,13 +46,12 @@ defmodule ElixirTools.Events.Adapters.AwsSns do
     id = uuid_module.uuid5(event.event_id_seed, uuid_seed_2)
 
     occurred_at = event.occurred_at || timex_module.now()
-    occurred_at = Timex.format!(occurred_at, "{ISO:Extended:Z}")
 
     %{
       id: id,
       action: String.upcase(event.name),
       group: group,
-      occurred_at: occurred_at,
+      occurred_at: Timex.format!(occurred_at, "{ISO:Extended:Z}"),
       version: event.version,
       payload: event.payload
     }

--- a/lib/events/adapters/aws_sns.ex
+++ b/lib/events/adapters/aws_sns.ex
@@ -15,6 +15,7 @@ defmodule ElixirTools.Events.Adapters.AwsSns do
            | {:uuid_module, module}
            | {:group, String.t()}
            | {:topic, String.t()}
+           | {:timex_module, module}
 
   @impl true
   @spec publish(Event.t(), [publish_opt]) :: :ok | {:error, term}
@@ -36,6 +37,7 @@ defmodule ElixirTools.Events.Adapters.AwsSns do
   @spec add_envelope(Event.t(), [publish_opt]) :: map
   defp add_envelope(event, opts) do
     uuid_module = opts[:uuid_module] || UUID
+    timex_module = opts[:timex_module] || Timex
 
     config = Application.get_env(:pagantis_elixir_tools, ElixirTools.Events)[:adapter_config]
     group = opts[:group] || Map.fetch!(config, :group)
@@ -43,7 +45,7 @@ defmodule ElixirTools.Events.Adapters.AwsSns do
     uuid_seed_2 = "#{event.name}-#{event.version}-#{event.event_id_seed_optional}"
     id = uuid_module.uuid5(event.event_id_seed, uuid_seed_2)
 
-    occurred_at = event.occurred_at || Timex.now()
+    occurred_at = event.occurred_at || timex_module.now()
     occurred_at = Timex.format!(occurred_at, "{ISO:Extended:Z}")
 
     %{

--- a/lib/events/event.ex
+++ b/lib/events/event.ex
@@ -11,13 +11,21 @@ defmodule ElixirTools.Events.Event do
           version: String.t(),
           payload: map,
           event_id_seed: Ecto.UUID.t(),
-          event_id_seed_optional: String.t()
+          event_id_seed_optional: String.t(),
+          occurred_at: DateTime.t() | nil
         }
 
   @typep return :: :ok | {:error, reason :: String.t()}
 
   @enforce_keys ~w(name event_id_seed)a
-  defstruct [:name, :event_id_seed, payload: %{}, version: "1.0.0", event_id_seed_optional: ""]
+  defstruct [
+    :name,
+    :event_id_seed,
+    payload: %{},
+    version: "1.0.0",
+    event_id_seed_optional: "",
+    occurred_at: nil
+  ]
 
   @spec publish(t, module | nil) :: return
   def publish(event, adapter \\ nil) do
@@ -38,10 +46,18 @@ defmodule ElixirTools.Events.Event do
          :ok <- validate_payload(event.payload),
          :ok <- validate_event_id_seed(event.event_id_seed),
          :ok <- validate_event_id_seed_optional(event.event_id_seed_optional),
+         :ok <- validate_occurred_at(event.occurred_at),
          :ok <- validate_version(event.version) do
       :ok
     end
   end
+
+  @spec validate_occurred_at(any) :: return
+  defp validate_occurred_at(%DateTime{}), do: :ok
+  defp validate_occurred_at(nil), do: :ok
+
+  defp validate_occurred_at(value),
+    do: {:error, "Expected a DateTime as occurred_at, but got #{inspect(value)}"}
 
   @spec validate_event_id_seed_optional(any) :: return
   defp validate_event_id_seed_optional(value) when is_binary(value), do: :ok

--- a/lib/events/event.ex
+++ b/lib/events/event.ex
@@ -21,10 +21,10 @@ defmodule ElixirTools.Events.Event do
   defstruct [
     :name,
     :event_id_seed,
+    :occurred_at,
     payload: %{},
     version: "1.0.0",
-    event_id_seed_optional: "",
-    occurred_at: nil
+    event_id_seed_optional: ""
   ]
 
   @spec publish(t, module | nil) :: return

--- a/test/events/adapters/aws_sns_test.exs
+++ b/test/events/adapters/aws_sns_test.exs
@@ -66,7 +66,7 @@ defmodule ElixirTools.Events.Adapters.AwsSnsTest do
     ]
 
     event = %{context.valid_event | event_id_seed_optional: "event_id_seed_optional"}
-    assert :ok == AwsSns.publish(event, opts)
+    assert AwsSns.publish(event, opts) == :ok
 
     assert_received [
       :uuid5,
@@ -87,7 +87,7 @@ defmodule ElixirTools.Events.Adapters.AwsSnsTest do
     occurred_at = Timex.to_datetime({{2015, 6, 29}, {4, 44, 44}}, "Etc/UTC")
     event = %{context.valid_event | occurred_at: occurred_at}
 
-    assert :ok == AwsSns.publish(event, opts)
+    assert AwsSns.publish(event, opts) == :ok
 
     assert_received [
       :sns_success,
@@ -117,7 +117,7 @@ defmodule ElixirTools.Events.Adapters.AwsSnsTest do
       default_region: "region"
     ]
 
-    assert :ok == AwsSns.publish(context.valid_event, opts)
+    assert AwsSns.publish(context.valid_event, opts) == :ok
 
     assert_received :timex_now
 
@@ -138,7 +138,7 @@ defmodule ElixirTools.Events.Adapters.AwsSnsTest do
       default_region: "region"
     ]
 
-    assert :ok == AwsSns.publish(context.valid_event, opts)
+    assert AwsSns.publish(context.valid_event, opts) == :ok
     assert_received [:sns_success, _]
     assert_received [:ex_aws_success, _, _]
   end

--- a/test/events/event_test.exs
+++ b/test/events/event_test.exs
@@ -106,6 +106,12 @@ defmodule ElixirTools.Events.EventTest do
                Event.publish(event, FakeAdapterSuccess)
     end
 
+    test "returns ok when event_id_seed_optional is string", context do
+      event = %{context.valid_event | event_id_seed_optional: "i am string"}
+
+      assert :ok == Event.publish(event, FakeAdapterSuccess)
+    end
+
     test "returns error when occurred_at is not a datetime", context do
       event = %{context.valid_event | occurred_at: "not a datetime"}
 

--- a/test/events/event_test.exs
+++ b/test/events/event_test.exs
@@ -105,5 +105,18 @@ defmodule ElixirTools.Events.EventTest do
       assert {:error, "Expected a string as event_id_seed_optional, but got 123"} ==
                Event.publish(event, FakeAdapterSuccess)
     end
+
+    test "returns error when occurred_at is not a datetime", context do
+      event = %{context.valid_event | occurred_at: "not a datetime"}
+
+      assert {:error, "Expected a DateTime as occurred_at, but got \"not a datetime\""} ==
+               Event.publish(event, FakeAdapterSuccess)
+    end
+
+    test "returns ok when occurred_at is datetime", context do
+      event = %{context.valid_event | occurred_at: Timex.now()}
+
+      assert :ok == Event.publish(event, FakeAdapterSuccess)
+    end
   end
 end

--- a/test/events/event_test.exs
+++ b/test/events/event_test.exs
@@ -26,103 +26,103 @@ defmodule ElixirTools.Events.EventTest do
 
   describe "publish/2" do
     test "returns :ok when it's succesfully sent", context do
-      assert :ok == Event.publish(context.valid_event, FakeAdapterSuccess)
+      assert Event.publish(context.valid_event, FakeAdapterSuccess) == :ok
     end
 
     test "returns error when adapter throws error", context do
-      assert {:error, %RuntimeError{message: "ERROR"}} ==
-               Event.publish(context.valid_event, FakeAdapterError)
+      assert Event.publish(context.valid_event, FakeAdapterError) ==
+               {:error, %RuntimeError{message: "ERROR"}}
     end
 
     test "returns error when version is not a string", context do
       event = %{context.valid_event | version: 1}
 
-      assert {:error, "Expected a string with a version"} ==
-               Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) ==
+               {:error, "Expected a string with a version"}
     end
 
     test "returns error when version is not having major.minor.fix format", context do
       event = %{context.valid_event | version: "1.1"}
 
-      assert {:error, "Expected version with 3 dots, but received 1.1"} ==
-               Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) ==
+               {:error, "Expected version with 3 dots, but received 1.1"}
     end
 
     test "returns error when version major is not an integer", context do
       event = %{context.valid_event | version: "1a.1.1"}
 
-      assert {:error, "Expected a number for the major, but received 1a.1.1"} ==
-               Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) ==
+               {:error, "Expected a number for the major, but received 1a.1.1"}
     end
 
     test "returns error when version minor is not an integer", context do
       event = %{context.valid_event | version: "1.1a.1"}
 
-      assert {:error, "Expected a number for the minor, but received 1.1a.1"} ==
-               Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) ==
+               {:error, "Expected a number for the minor, but received 1.1a.1"}
     end
 
     test "returns error when version fix is not an integer", context do
       event = %{context.valid_event | version: "1.1.1a"}
 
-      assert {:error, "Expected a number for the fix, but received 1.1.1a"} ==
-               Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) ==
+               {:error, "Expected a number for the fix, but received 1.1.1a"}
     end
 
     test "returns error when name does not contain an underscore", context do
       event = %{context.valid_event | name: "EVENT"}
 
-      assert {:error, "Expected an underscore in the event name, but got EVENT instead"} ==
-               Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) ==
+               {:error, "Expected an underscore in the event name, but got EVENT instead"}
     end
 
     test "returns error when name is not a string", context do
       event = %{context.valid_event | name: :EVENT}
 
-      assert {:error, "Expected a string as event name, but got :EVENT"} ==
-               Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) ==
+               {:error, "Expected a string as event name, but got :EVENT"}
     end
 
     test "returns error when they payload is not a map", context do
       Enum.map([[], false, nil, 3, 0, "string", 'binary', :atom], fn value ->
         event = %{context.valid_event | payload: value}
 
-        assert {:error, "Expected payload to be a map"} ==
-                 Event.publish(event, FakeAdapterSuccess)
+        assert Event.publish(event, FakeAdapterSuccess) ==
+                 {:error, "Expected payload to be a map"}
       end)
     end
 
     test "returns error when event_id_seed is not a UUID string", context do
       event = %{context.valid_event | event_id_seed: "not uuid string"}
 
-      assert {:error, "Expected a UUID string as event_id_seed, but got \"not uuid string\""} ==
-               Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) ==
+               {:error, "Expected a UUID string as event_id_seed, but got \"not uuid string\""}
     end
 
     test "returns error when event_id_seed_optional is not a string", context do
       event = %{context.valid_event | event_id_seed_optional: 123}
 
-      assert {:error, "Expected a string as event_id_seed_optional, but got 123"} ==
-               Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) ==
+               {:error, "Expected a string as event_id_seed_optional, but got 123"}
     end
 
     test "returns ok when event_id_seed_optional is string", context do
       event = %{context.valid_event | event_id_seed_optional: "i am string"}
 
-      assert :ok == Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) == :ok
     end
 
     test "returns error when occurred_at is not a datetime", context do
       event = %{context.valid_event | occurred_at: "not a datetime"}
 
-      assert {:error, "Expected a DateTime as occurred_at, but got \"not a datetime\""} ==
-               Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) ==
+               {:error, "Expected a DateTime as occurred_at, but got \"not a datetime\""}
     end
 
     test "returns ok when occurred_at is datetime", context do
       event = %{context.valid_event | occurred_at: Timex.now()}
 
-      assert :ok == Event.publish(event, FakeAdapterSuccess)
+      assert Event.publish(event, FakeAdapterSuccess) == :ok
     end
   end
 end


### PR DESCRIPTION
#### :tophat: Problem
Sometimes we want to overwrite `occurred_at`. Now for the historical events

#### :pushpin: Solution
Let's add an optional field to `Event`, if it's presented - use it, if not - `Timex.now`

#### :ghost: GIF
 ![](https://media.giphy.com/media/2ytsKwTeyPJSZIOlO5/giphy.gif)
