### PR TITLE
update toolversions to v1.9-o22

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.8.1-otp-21
-erlang 21.1
+elixir 1.9.0-otp-22
+erlang 22.0


### PR DESCRIPTION
#### :tophat: Problem
The rest of our services are running on v1.9 while here we use 1.8 for testing

#### :pushpin: Solution
Update the tool version to elixir 1.9-otp22

#### :ghost: GIF
 ![](https://media.giphy.com/media/CjmvTCZf2U3p09Cn0h/giphy.gif)
