### PR TITLE
PAYM-2347 Add event_handler & not_sent_event

### DIFF
--- a/lib/events/README.md
+++ b/lib/events/README.md
@@ -27,6 +27,29 @@ config :pagantis_elixir_tools, ElixirTools.Events,
   }
 ```
 
+Add
+```elixir
+supervisor(Task.Supervisor, [[name: ElixirTools.TaskSupervisor]])
+```
+to your `application.ex`. It's needed to be able to sent event async.
+
+Events which are failed to sent(wrong config, infrastructure issues etc.) will be save to `not_sent_events` table. 
+To create this table
+```bash
+mix ecto.gen.migration create_not_sent_events
+```
+
+and add the following to the migration file inside the `change` function
+```elixir
+create table(:not_sent_events, primary_key: false) do
+  add(:id, :uuid, primary_key: true)
+  add(:content, :text)
+  add(:is_sent, :boolean, default: false)
+  timestamps()
+end
+```
+
+
 For local development with localstack, also add:
 
 ```elixir
@@ -51,3 +74,7 @@ If all values will be the same -> event_id will be the same -> event will be upd
 * `version` - optional, string, `\d+.\d+.\d+` format
 
 An example can be found here [https://github.com/digitalorigin/pg-elixir-tools/tree/master/examples/events](https://github.com/digitalorigin/pg-elixir-tools/tree/master/examples/events).
+
+In case if event was not sent:
+* new row will be added to `not_sent_events` table
+* telemetry metric will be emitted with the following data `[:do_elixir_tools, :events, :not_sent], %{error_info: error_info}`. So you can attach to it with Rollbar/Logger

--- a/lib/events/README.md
+++ b/lib/events/README.md
@@ -62,16 +62,16 @@ config :ex_aws, :sns,
 
 ## Usage
 ```elixir
+EventHandler.create(name, payload, event_id_seed, [{:event_id_seed_optional, event_id_seed_optional}, {:occurred_at, occurred_at}])
 Event.publish(%Event{name: "NAME_EXAMPLE", event_id_seed: "f367d382-6452-435c-ad83-3477bd530349", payload: %{key: "value"}, version: "1.0.0"}
 ```
 Where:
 * `name` - obligatory, string, contains at least one `_`
+* `payload` - optional, map
 * `event_id_seed` - obligatory, string in UUID format, which will be used together with `name`, `version` & `event_id_seed_optional` as a seed for event_id generation. 
 If all values will be the same -> event_id will be the same -> event will be updated in S3.
 * `event_id_seed_optional` - string, optional part used for event_id generation. By default - ""(empty string)
 * `occurred_at` - optional, datetime, if provided - overwrite `current datetime` sent by default
-* `payload` - optional, map
-* `version` - optional, string, `\d+.\d+.\d+` format
 
 An example can be found here [https://github.com/digitalorigin/pg-elixir-tools/tree/master/examples/events](https://github.com/digitalorigin/pg-elixir-tools/tree/master/examples/events).
 

--- a/lib/events/README.md
+++ b/lib/events/README.md
@@ -77,4 +77,4 @@ An example can be found here [https://github.com/digitalorigin/pg-elixir-tools/t
 
 In case if event was not sent:
 * new row will be added to `not_sent_events` table
-* telemetry metric will be emitted with the following data `[:do_elixir_tools, :events, :not_sent], %{error_info: error_info}`. So you can attach to it with Rollbar/Logger
+* telemetry metric will be emitted with the following data `[:pagantis_elixir_tools, :events, :not_sent], %{error_info: error_info}`. So you can attach to it with Rollbar/Logger

--- a/lib/events/event_handler.ex
+++ b/lib/events/event_handler.ex
@@ -64,7 +64,10 @@ defmodule ElixirTools.Events.EventHandler do
       {:error, reason} ->
         error_info = event |> Map.from_struct() |> Map.put(:reason, inspect(reason))
 
-        telemetry_module.execute([:do_elixir_tools, :events, :not_sent], %{error_info: error_info})
+        telemetry_module.execute(
+          [:pagantis_elixir_tools, :events, :not_sent],
+          %{error_info: error_info}
+        )
 
         not_sent_event_module.create!(%{content: Jason.encode!(error_info)})
         :error

--- a/lib/events/event_handler.ex
+++ b/lib/events/event_handler.ex
@@ -1,0 +1,72 @@
+defmodule ElixirTools.Events.EventHandler do
+  alias ElixirTools.Events.{Event, NotSentEvent}
+
+  @type events_opt ::
+          {:event_handler_module, module}
+          | {:task_supervisor_module, module}
+          | {:event_module, module}
+          | {:not_sent_event_module, module}
+  @callback send_event(any, [events_opt]) :: :ok
+
+  @callback create(event_name, payload) :: Event.t()
+  @callback publish(Event.t(), [events_opt]) :: :ok
+
+  @optional_callbacks send_event: 2,
+                      create: 2,
+                      publish: 2
+
+  @typep event_name :: String.t()
+  @typep payload :: map
+  @typep event_id_seed :: Ecto.UUID.t()
+  @typep event_id_seed_optional :: String.t()
+
+  @spec create(event_name, payload, event_id_seed) :: Event.t()
+  def create(event_name, payload, event_id_seed) do
+    %Event{name: event_name, payload: payload, event_id_seed: event_id_seed}
+  end
+
+  @typep create_optional ::
+           {:event_id_seed_optional, event_id_seed_optional}
+           | {:occurred_at, DateTime.t()}
+  @spec create(event_name, payload, event_id_seed, [create_optional]) :: Event.t()
+  def create(event_name, payload, event_id_seed, create_optional) do
+    event_id_seed_optional = create_optional[:event_id_seed_optional] || ""
+    occurred_at = create_optional[:occurred_at]
+
+    %Event{
+      name: event_name,
+      payload: payload,
+      event_id_seed: event_id_seed,
+      event_id_seed_optional: event_id_seed_optional,
+      occurred_at: occurred_at
+    }
+  end
+
+  @spec publish(Event.t(), [events_opt]) :: :ok
+  def publish(event, opts) do
+    task_supervisor_module = opts[:task_supervisor_module] || Task.Supervisor
+
+    task_supervisor_module.async_nolink(PgPayments.TaskSupervisor, fn ->
+      publish_event_call(event, opts)
+    end)
+
+    :ok
+  end
+
+  @spec publish_event_call(Event.t(), [events_opt]) :: :ok | :error
+  def publish_event_call(event, opts) do
+    event_module = opts[:event_module] || Event
+    not_sent_event_module = opts[:not_sent_event_module] || NotSentEvent
+
+    case event_module.publish(event) do
+      {:error, reason} ->
+        error_info = event |> Map.from_struct() |> Map.put(:reason, inspect(reason))
+        :telemetry.execute([:do_elixir_tools, :events, :not_sent], %{error_info: error_info})
+        not_sent_event_module.create!(%{content: Jason.encode!(error_info)})
+        :error
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/events/event_handler.ex
+++ b/lib/events/event_handler.ex
@@ -47,7 +47,7 @@ defmodule ElixirTools.Events.EventHandler do
   def publish(event, opts) do
     task_supervisor_module = opts[:task_supervisor_module] || Task.Supervisor
 
-    task_supervisor_module.async_nolink(PgPayments.TaskSupervisor, fn ->
+    task_supervisor_module.async_nolink(ElixirTools.TaskSupervisor, fn ->
       publish_event_call(event, opts)
     end)
 

--- a/lib/events/not_sent_event.ex
+++ b/lib/events/not_sent_event.ex
@@ -1,7 +1,7 @@
 defmodule ElixirTools.Events.NotSentEvent do
   @moduledoc """
-      Schema used for saving not sent (due to a failure) events to DB.
-      They supposed to be resend later, after this a field `is_sent` has to be set to `true`
+  Schema used for saving not sent (due to a failure) events to DB.
+  They supposed to be resend later, after this a field `is_sent` has to be set to `true`
   """
 
   use ElixirTools.Schema

--- a/lib/events/not_sent_event.ex
+++ b/lib/events/not_sent_event.ex
@@ -1,0 +1,35 @@
+defmodule ElixirTools.Events.NotSentEvent do
+  @moduledoc """
+      Schema used for saving not sent (due to a failure) events to DB.
+      They supposed to be resend later, after this a field `is_sent` has to be set to `true`
+  """
+
+  use ElixirTools.Schema
+
+  alias __MODULE__
+  alias Ecto.Changeset
+
+  @type external_reference :: String.t()
+  @type t :: %NotSentEvent{
+          id: id | nil,
+          content: String.t(),
+          is_sent: boolean
+        }
+
+  @allowed_fields ~w(content is_sent)a
+  @required_fields ~w(content is_sent)a
+
+  schema "not_sent_events" do
+    field(:content, :string)
+    field(:is_sent, :boolean, default: false)
+
+    timestamps()
+  end
+
+  @impl true
+  def changeset(params) do
+    %NotSentEvent{}
+    |> Changeset.cast(params, @allowed_fields)
+    |> Changeset.validate_required(@required_fields)
+  end
+end

--- a/test/events/event_handler_test.exs
+++ b/test/events/event_handler_test.exs
@@ -27,8 +27,8 @@ defmodule ElixirTools.Events.EventHandlerTest do
       event_name = "CHARGE_CREATED"
       event_id_seed = "22833003-fb25-4961-8373-f01da28ec820"
 
-      assert event == EventHandler.create(event_name, payload, event_id_seed)
-      assert :ok == Event.validate(event)
+      assert EventHandler.create(event_name, payload, event_id_seed) == event
+      assert Event.validate(event) == :ok
     end
   end
 
@@ -45,11 +45,8 @@ defmodule ElixirTools.Events.EventHandlerTest do
       ]
 
       event = %{event | event_id_seed_optional: event_id_seed_optional, occurred_at: occurred_at}
-
-      assert event ==
-               EventHandler.create(event_name, payload, event_id_seed, optional_params)
-
-      assert :ok == Event.validate(event)
+      assert EventHandler.create(event_name, payload, event_id_seed, optional_params) == event
+      assert Event.validate(event) == :ok
     end
 
     test "if event_id_seed_optional is nil - it's replaced with empty string", %{payload: payload} do
@@ -106,7 +103,7 @@ defmodule ElixirTools.Events.EventHandlerTest do
     test "event is published as expected", %{event: event} do
       opts = [{:task_supervisor_module, TaskSupervisorFake}, {:event_module, EventFakeOk}]
 
-      assert :ok == EventHandler.publish(event, opts)
+      assert EventHandler.publish(event, opts) == :ok
 
       assert_received(:start)
       assert_received({:publish, ^event})
@@ -119,7 +116,7 @@ defmodule ElixirTools.Events.EventHandlerTest do
         {:telemetry_module, TelemetryFake}
       ]
 
-      assert :ok == EventHandler.publish(event, opts)
+      assert EventHandler.publish(event, opts) == :ok
 
       assert_received(:start)
       assert_received({:publish, ^event})
@@ -132,7 +129,7 @@ defmodule ElixirTools.Events.EventHandlerTest do
         {:telemetry_module, TelemetryFake}
       ]
 
-      assert :ok == EventHandler.publish(event, opts)
+      assert EventHandler.publish(event, opts) == :ok
 
       expected_reason =
         "%RuntimeError{message: \"sns not supported in region eu-north-1 for partition aws\"}"
@@ -142,7 +139,7 @@ defmodule ElixirTools.Events.EventHandlerTest do
       assert_received(
         {:telemetry_execute,
          %{
-           event_name: [:do_elixir_tools, :events, :not_sent],
+           event_name: [:pagantis_elixir_tools, :events, :not_sent],
            measurements: %{error_info: ^expected_error_info}
          }}
       )
@@ -163,7 +160,7 @@ defmodule ElixirTools.Events.EventHandlerTest do
         {:not_sent_event_module, FakeNotSentEvent}
       ]
 
-      assert :ok == EventHandler.publish(event, opts)
+      assert EventHandler.publish(event, opts) == :ok
 
       assert_received(
         {:create_not_sent_event,

--- a/test/events/event_handler_test.exs
+++ b/test/events/event_handler_test.exs
@@ -1,0 +1,151 @@
+defmodule ElixirTools.Events.EventHandlerTest do
+  use ExUnit.Case, async: true
+
+  alias ElixirTools.Events.{EventHandler, Event}
+
+  setup do
+    payload = %{
+      amount: 1,
+      charge_id: "charge_id",
+      created_at: "created_at",
+      payment_method_id: "payment_method_id",
+      type: :card
+    }
+
+    event = %Event{
+      name: "CHARGE_CREATED",
+      payload: payload,
+      version: "1.0.0",
+      event_id_seed: "22833003-fb25-4961-8373-f01da28ec820"
+    }
+
+    %{payload: payload, event: event}
+  end
+
+  describe "create/3" do
+    test "event is created as expected", %{payload: payload, event: event} do
+      event_name = "CHARGE_CREATED"
+      event_id_seed = "22833003-fb25-4961-8373-f01da28ec820"
+
+      assert event == EventHandler.create(event_name, payload, event_id_seed)
+      assert :ok == Event.validate(event)
+    end
+  end
+
+  describe "create/4" do
+    test "event is created as expected", %{payload: payload, event: event} do
+      event_name = "CHARGE_CREATED"
+      event_id_seed = "22833003-fb25-4961-8373-f01da28ec820"
+      event_id_seed_optional = "event_id_seed_optional"
+      occurred_at = Timex.now()
+
+      optional_params = [
+        {:event_id_seed_optional, "event_id_seed_optional"},
+        {:occurred_at, occurred_at}
+      ]
+
+      event = %{event | event_id_seed_optional: event_id_seed_optional, occurred_at: occurred_at}
+
+      assert event ==
+               EventHandler.create(event_name, payload, event_id_seed, optional_params)
+
+      assert :ok == Event.validate(event)
+    end
+
+    test "if event_id_seed_optional is nil - it's replaced with empty string", %{payload: payload} do
+      event_name = "CHARGE_CREATED"
+      event_id_seed = "22833003-fb25-4961-8373-f01da28ec820"
+
+      optional_params = [
+        {:occurred_at, Timex.now()}
+      ]
+
+      assert %{event_id_seed_optional: ""} =
+               EventHandler.create(event_name, payload, event_id_seed, optional_params)
+    end
+  end
+
+  describe "publish/2" do
+    defmodule TaskSupervisorFake do
+      use ElixirTools.ContractImpl, module: Task.Supervisor
+      @impl true
+      def async_nolink(_, function) do
+        send(self(), :start)
+
+        function.()
+      end
+    end
+
+    defmodule EventFakeOk do
+      use ElixirTools.ContractImpl, module: ElixirTools.Events.Event
+      @impl true
+      def publish(event) do
+        send(self(), {:publish, event})
+
+        :ok
+      end
+    end
+
+    defmodule EventFakeFail do
+      use ElixirTools.ContractImpl, module: ElixirTools.Events.Event
+      @impl true
+      def publish(event) do
+        send(self(), {:publish, event})
+
+        {:error,
+         %RuntimeError{message: "sns not supported in region eu-north-1 for partition aws"}}
+      end
+    end
+
+    test "event is published as expected", %{event: event} do
+      opts = [{:task_supervisor_module, TaskSupervisorFake}, {:event_module, EventFakeOk}]
+
+      assert :ok == EventHandler.publish(event, opts)
+
+      assert_received(:start)
+      assert_received({:publish, ^event})
+    end
+
+    test "event publishing call returns error", %{event: event} do
+      opts = [{:task_supervisor_module, TaskSupervisorFake}, {:event_module, EventFakeFail}]
+
+      assert :ok == EventHandler.publish(event, opts)
+
+      assert_received(:start)
+
+      assert_received({:publish, ^event})
+
+      expected_reason =
+        "%RuntimeError{message: \"sns not supported in region eu-north-1 for partition aws\"}"
+
+      expected_response_data = event |> Map.from_struct() |> Map.put(:reason, expected_reason)
+      # TEST TELEMETRY CALL HERE
+    end
+
+    test "save event to DB if it was not published", %{event: event} do
+      defmodule FakeNotSentEvent do
+        use ElixirTools.ContractImpl, module: ElixirTools.Events.NotSentEvent
+
+        def create!(params) do
+          send(self(), {:create_not_sent_event, params})
+        end
+      end
+
+      opts = [
+        {:task_supervisor_module, TaskSupervisorFake},
+        {:event_module, EventFakeFail},
+        {:not_sent_event_module, FakeNotSentEvent}
+      ]
+
+      assert :ok == EventHandler.publish(event, opts)
+
+      assert_received(
+        {:create_not_sent_event,
+         %{
+           content:
+             "{\"event_id_seed\":\"22833003-fb25-4961-8373-f01da28ec820\",\"event_id_seed_optional\":\"\",\"name\":\"CHARGE_CREATED\",\"occurred_at\":null,\"payload\":{\"amount\":1,\"charge_id\":\"charge_id\",\"created_at\":\"created_at\",\"payment_method_id\":\"payment_method_id\",\"type\":\"card\"},\"reason\":\"%RuntimeError{message: \\\"sns not supported in region eu-north-1 for partition aws\\\"}\",\"version\":\"1.0.0\"}"
+         }}
+      )
+    end
+  end
+end

--- a/test/events/not_sent_event_test.exs
+++ b/test/events/not_sent_event_test.exs
@@ -1,0 +1,23 @@
+defmodule ElixirTools.Events.NotSentEventTest do
+  use ExUnit.Case, async: true
+
+  alias ElixirTools.Events.NotSentEvent
+
+  setup do
+    %{valid_params: %{content: "content"}}
+  end
+
+  describe "changeset/1" do
+    test "correct cast", %{valid_params: valid_params} do
+      changeset = NotSentEvent.changeset(valid_params)
+      assert changeset.valid?
+      assert changeset.changes.content == valid_params[:content]
+    end
+
+    test "is not valid when content is missing", %{valid_params: valid_params} do
+      params = Map.delete(valid_params, :content)
+      changeset = NotSentEvent.changeset(params)
+      refute changeset.valid?
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Problem
Currently we have `event_handler` & `not_sent_event` in `pg-payments`, but this functionality will be useful in all the projects

#### :pushpin: Solution
Move it to this repo

➡️➡️➡️ Most of the code is just copied from `pg-payments`. The only significant difference is that instead of sending a message to `Rollbar` we emit it with telemetry. The reason is that not all apps need/can use Rollbar(PCI ones can't)

#### :ghost: GIF
 ![](https://media.giphy.com/media/WsvLlmmjx9tnmeTPNc/giphy.gif)
