### PR TITLE
HttpClient env vars now read at runtime

### DIFF
--- a/lib/http_client/http_client.ex
+++ b/lib/http_client/http_client.ex
@@ -119,10 +119,12 @@ defmodule ElixirTools.HttpClient do
     ]
   end
 
+  @spec http_client() :: module
   defp http_client() do
     Application.get_env(:pagantis_elixir_tools, HttpClient)[:http_client] || HTTPoison
   end
 
+  @spec default_connection_options() :: [recv_timeout: pos_integer]
   defp default_connection_options() do
     timeout = Application.get_env(:pagantis_elixir_tools, HttpClient)[:response_timeout]
     [recv_timeout: timeout]


### PR DESCRIPTION
#### :tophat: Problem
Env vars in HttpClient were being read at compile-time which caused problems with recompilations...

#### :pushpin: Solution
Read the env vars at runtime.

#### :ghost: GIF
 ![](https://media.giphy.com/media/onOWJOc7U5GAE/giphy.gif)
