### PR TITLE
Use credo check for specs in circle_ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,3 +69,15 @@ jobs:
               exit $score
             fi
             exit 0
+
+      - run:
+          name: Check if all specs are in place
+          command: |
+            set +e
+            max_credo_score=0
+            mix credo -C check_specs
+            score=$?
+            if [ $score -gt $max_credo_score ]; then
+              exit $score
+            fi
+            exit 0

--- a/.credo.exs
+++ b/.credo.exs
@@ -9,6 +9,14 @@
   # You can have as many configs as you like in the `configs:` field.
   configs: [
     %{
+      name: "check_specs",
+      requires: [],
+      strict: true,
+      color: true,
+      files: %{included: ["lib/"], excluded: ["test/"]},
+      checks: [{Credo.Check.Readability.Specs}]
+    },
+    %{
       #
       # Run any exec using `mix credo -C <name>`. If no exec name is given
       # "default" is used.

--- a/lib/contract_impl/contract_impl.ex
+++ b/lib/contract_impl/contract_impl.ex
@@ -36,12 +36,12 @@ defmodule ElixirTools.ContractImpl do
   end
 
   @no_module_error "There was no module specified."
-  @spec arg_to_module(any) :: module | no_return()
+  @spec arg_to_module!(any) :: module | no_return()
   def arg_to_module!({_, _, module_param}) do
     module_param
     |> Enum.reduce("Elixir", &"#{&2}.#{to_string(&1)}")
     |> String.to_atom()
   end
 
-  def arg_to_module(_), do: raise(@no_module_error)
+  def arg_to_module!(_), do: raise(@no_module_error)
 end

--- a/lib/fixture/fixture.ex
+++ b/lib/fixture/fixture.ex
@@ -8,6 +8,7 @@ defmodule ElixirTools.Fixture do
   @doc """
   Looks for a json fixture and decodes it
   """
+  @spec load_json!(String.t(), String.t()) :: term | no_return
   def load_json!(fixture, location \\ @fixture_location) do
     fixture
     |> load!(location)
@@ -17,6 +18,7 @@ defmodule ElixirTools.Fixture do
   @doc """
   Looks for a fixture without decoding
   """
+  @spec load!(String.t(), String.t()) :: String.t()
   def load!(fixture, location \\ @fixture_location) do
     file = location <> fixture <> ".json"
     file |> File.read!()

--- a/lib/metrix/supervisor.ex
+++ b/lib/metrix/supervisor.ex
@@ -9,6 +9,7 @@ defmodule ElixirTools.Metrix.Supervisor do
                        :recurrent_metrics
                      ]
 
+  @spec start_link(any) :: {:ok, pid} | {:error, term}
   def start_link(_ \\ []) do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end


### PR DESCRIPTION
#### :tophat: Problem
We have a check for missing specs in credo config but we use it only in pg-payments

#### :pushpin: Solution
Use it!

#### :ghost: GIF
 ![](https://media.giphy.com/media/q7dOUT9sCjj2M/giphy.gif)
