### PR TITLE
Make reading of :repo at runtime

### DIFF
--- a/lib/schema/schema.ex
+++ b/lib/schema/schema.ex
@@ -6,8 +6,9 @@ defmodule ElixirTools.Schema do
 
   @type id :: Ecto.UUID.t()
 
-  @default_repo Application.get_env(:pagantis_elixir_tools, ElixirTools.Schema)[:default_repo]
-  def default_repo, do: @default_repo
+  def default_repo do
+    Application.get_env(:pagantis_elixir_tools, ElixirTools.Schema)[:default_repo]
+  end
 
   # Required methods in schemas
   @callback changeset(map) :: Changeset.t()


### PR DESCRIPTION
#### :tophat: Problem
Repo was being read at compile time, which meant that if the `config :pagantis_elixir_tools, ElixirTools.Schema, default_repo: ...` was not set in your application's config BEFORE Elixir-tools was compiled, the `default_repo` was always nil.

#### :pushpin: Solution
Read it at runtime

#### :ghost: GIF
 ![](https://media.giphy.com/media/LpctNbdeSaRvPP7jxM/giphy-downsized.gif)
