### PR TITLE
Implement option to add custom fixture file extension

### DIFF
--- a/lib/fixture/fixture.ex
+++ b/lib/fixture/fixture.ex
@@ -18,9 +18,9 @@ defmodule ElixirTools.Fixture do
   @doc """
   Looks for a fixture without decoding
   """
-  @spec load!(String.t(), String.t()) :: String.t()
-  def load!(fixture, location \\ @fixture_location) do
-    file = location <> fixture <> ".json"
+  @spec load!(String.t(), String.t(), String.t()) :: String.t()
+  def load!(fixture, location \\ @fixture_location, file_extension \\ ".json") do
+    file = location <> fixture <> file_extension
     file |> File.read!()
   end
 end


### PR DESCRIPTION
#### :tophat: Problem
No way to load fixtures that are not .json files (such as .tsv files).

#### :pushpin: Solution
Add option for this.

#### :ghost: GIF
 ![](https://media.giphy.com/media/26gYK80dicRdI8bYI/giphy-downsized.gif)
