### PR TITLE
Metrix default tags no longer required

### DIFF
--- a/lib/metrix/metrix.ex
+++ b/lib/metrix/metrix.ex
@@ -63,8 +63,7 @@ defmodule ElixirTools.Metrix do
   @spec to_tags(Adapter.tag_map(), [opts]) :: any
   def to_tags(tags, opts) do
     adapter_module = opts[:adapter_module] || @adapter
-    default_tags = Application.get_env(:pagantis_elixir_tools, Metrix)[:default_tags]
-
+    default_tags = Application.get_env(:pagantis_elixir_tools, Metrix)[:default_tags] || %{}
     adapter_module.to_tags(Map.merge(tags, default_tags))
   end
 

--- a/test/metrix/metrix_test.exs
+++ b/test/metrix/metrix_test.exs
@@ -132,6 +132,27 @@ defmodule ElixirTools.Metrix.ElixirTools.MetrixTest do
     end
   end
 
+  describe "to_tags/1" do
+    setup do
+      original_config = Application.get_env(:pagantis_elixir_tools, ElixirTools.Metrix)
+
+      on_exit(fn ->
+        Application.put_env(:pagantis_elixir_tools, ElixirTools.Metrix, original_config)
+      end)
+    end
+
+    test "when no tags are set in the config" do
+      config_no_tags =
+        :pagantis_elixir_tools
+        |> Application.get_env(ElixirTools.Metrix)
+        |> Keyword.delete_first(:default_tags)
+
+      Application.put_env(:pagantis_elixir_tools, ElixirTools.Metrix, config_no_tags)
+
+      assert ElixirTools.Metrix.to_tags(%{}, adapter_module: FailAdapter) == %{}
+    end
+  end
+
   defp await_execution() do
     :sys.get_state(ElixirTools.Metrix)
   end


### PR DESCRIPTION
#### :tophat: Problem
Default tags were giving a weird error, but in general it's not necessary to have default tags

#### :pushpin: Solution
Make default tags optional

#### :ghost: GIF
 ![](https://media.giphy.com/media/Mp4hQy51LjY6A/giphy.gif)
