### PR TITLE
Allow metrix to be disabled with a flag + test output fixes

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -5,7 +5,9 @@ config :pagantis_elixir_tools, ElixirTools.JsonApi.Controller,
 
 config :pagantis_elixir_tools, ElixirTools.Metrix,
   default_tags: %{default_tag: "1", other_default_tag: "2"},
-  adapter: ElixirTools.Metrix.Adapters.Log
+  adapter: ElixirTools.Metrix.Adapters.Log,
+  enabled: false,
+  recurrent_metrics: []
 
 config :pagantis_elixir_tools, ElixirTools.Schema, default_repo: Support.TestRepo
 

--- a/lib/metrix/supervisor.ex
+++ b/lib/metrix/supervisor.ex
@@ -3,6 +3,8 @@ defmodule ElixirTools.Metrix.Supervisor do
 
   use Supervisor
 
+  require Logger
+
   @typep child :: Supervisor.child_spec() | module | {module, []}
 
   @recurrent_metrics Application.get_env(:pagantis_elixir_tools, ElixirTools.Metrix)[
@@ -11,7 +13,12 @@ defmodule ElixirTools.Metrix.Supervisor do
 
   @spec start_link(any) :: {:ok, pid} | {:error, term}
   def start_link(_ \\ []) do
-    Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+    if metrix_enabled?() do
+      Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+    else
+      Logger.info("Metrix did not start because it's disabled.")
+      :ok
+    end
   end
 
   @impl true
@@ -29,4 +36,10 @@ defmodule ElixirTools.Metrix.Supervisor do
 
   @spec add_recurrent_metric_children([child]) :: [child]
   defp add_recurrent_metric_children(children), do: children ++ @recurrent_metrics
+
+  @spec metrix_enabled? :: boolean
+  defp metrix_enabled? do
+    enabled_values = [nil, true, "true"]
+    Application.get_env(:pagantis_elixir_tools, ElixirTools.Metrix)[:enabled] in enabled_values
+  end
 end

--- a/test/metrix/adapters/log_test.exs
+++ b/test/metrix/adapters/log_test.exs
@@ -1,4 +1,4 @@
-defmodule Metrix.Adapters.LogTest do
+defmodule ElixirTools.Metrix.Adapters.LogTest do
   use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
@@ -15,7 +15,7 @@ defmodule Metrix.Adapters.LogTest do
   end
 
   test "connect" do
-    log_message = capture_log(fn -> Log.connect() end)
+    log_message = capture_log(&Log.connect/0)
     assert log_message =~ "Statsd log adapter: Connect"
   end
 

--- a/test/metrix/adapters/log_test.exs
+++ b/test/metrix/adapters/log_test.exs
@@ -1,22 +1,27 @@
-defmodule ElixirTools.Metrix.Adapters.LogTest do
+defmodule Metrix.Adapters.LogTest do
   use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
+  import ElixirTools.MetrixHelper
 
+  alias ElixirTools.Metrix
   alias ElixirTools.Metrix.Adapters.Log
+
+  setup :start_supervisor
 
   setup do
     Logger.configure(level: :debug)
+    :ok
   end
 
   test "connect" do
-    log_message = capture_log(&Log.connect/0)
+    log_message = capture_log(fn -> Log.connect() end)
     assert log_message =~ "Statsd log adapter: Connect"
   end
 
   @methods ~w(count increment decrement gauge histogram timing)
   Enum.each(@methods, fn method_name ->
-    test "#{method_name} logs the correct message through ElixirTools.Metrix" do
+    test "#{method_name} logs the correct message through Metrix" do
       method = String.to_atom(unquote(method_name))
       metric = "my_metric"
       value = "my_value"
@@ -25,8 +30,8 @@ defmodule ElixirTools.Metrix.Adapters.LogTest do
 
       log_message =
         capture_log(fn ->
-          apply(ElixirTools.Metrix, method, args)
-          :sys.get_state(ElixirTools.Metrix)
+          apply(Metrix, method, args)
+          :sys.get_state(Metrix)
         end)
 
       assert log_message =~

--- a/test/metrix/supervisor_test.exs
+++ b/test/metrix/supervisor_test.exs
@@ -1,7 +1,11 @@
 defmodule ElixirTools.Metrix.SupervisorTest do
   use ExUnit.Case, async: false
 
+  import ElixirTools.MetrixHelper
+
   alias ElixirTools.Metrix
+
+  setup :start_supervisor
 
   setup do
     Logger.configure(level: :debug)

--- a/test/support/metrix_helper.ex
+++ b/test/support/metrix_helper.ex
@@ -1,0 +1,25 @@
+defmodule ElixirTools.MetrixHelper do
+  import ExUnit.Callbacks
+
+  alias ElixirTools.Metrix
+
+  @doc """
+  Starts the metrix supervisor. You can use this as an exunit setup callback:
+
+  ```
+  import ElixirTools.MetrixHelper
+
+  setup :start_supervisor
+  ```
+  """
+  def start_supervisor(_ \\ %{}) do
+    initial_config = Application.get_env(:pagantis_elixir_tools, Metrix)
+    tmp_config = Keyword.put(initial_config, :enabled, true)
+    on_exit(fn -> Application.put_env(:pagantis_elixir_tools, Metrix, initial_config) end)
+    Application.put_env(:pagantis_elixir_tools, Metrix, tmp_config)
+
+    start_supervised(Metrix.Supervisor)
+
+    :ok
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,1 @@
 ExUnit.start(capture_log: true)
-
-ElixirTools.Metrix.Supervisor.start_link()


### PR DESCRIPTION
#### :tophat: Problem
We need to be able to disable metrix in environments.

#### :pushpin: Solution
This PR introduces the flag `:enabled` to metrix, allowing it to be turned off in the configuration. Also noticed that there were some issues with logs, and solved them in the same PR as they are kind of related.

#### :ghost: GIF
 ![](https://media.giphy.com/media/YqE3jbSQQR6x9g19Kj/giphy.gif)
