### PR TITLE
Fix: supervisor should return :ignore instead of :ok

### DIFF
--- a/lib/metrix/supervisor.ex
+++ b/lib/metrix/supervisor.ex
@@ -17,7 +17,7 @@ defmodule ElixirTools.Metrix.Supervisor do
       Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
     else
       Logger.info("Metrix did not start because it's disabled.")
-      :ok
+      :ignore
     end
   end
 


### PR DESCRIPTION
#### :tophat: Problem
```
** (Mix) Could not start application pg_issuing: PgIssuing.Application.start(:normal, []) returned an error: shutdown: failed to start child: ElixirTools.Metrix.Supervisor
    ** (EXIT) :ok
```
#### :pushpin: Solution
Supervisor should return :ignore instead of :ok

#### :ghost: GIF
 ![](https://media.giphy.com/media/nKN7E76a27Uek/giphy.gif)
