### PR TITLE
PAYM-2480 Remove obligatory _ in event name

### DIFF
--- a/lib/events/event.ex
+++ b/lib/events/event.ex
@@ -66,18 +66,9 @@ defmodule ElixirTools.Events.Event do
     do: {:error, "Expected a string as event_id_seed_optional, but got #{inspect(value)}"}
 
   @spec validate_name(any) :: return
-  defp validate_name(name) do
-    cond do
-      !is_binary(name) ->
-        {:error, "Expected a string as event name, but got #{inspect(name)}"}
+  defp validate_name(name) when is_binary(name), do: :ok
 
-      !String.contains?(name, "_") ->
-        {:error, "Expected an underscore in the event name, but got #{name} instead"}
-
-      true ->
-        :ok
-    end
-  end
+  defp validate_name(name), do: {:error, "Expected a string as event name, got #{inspect(name)}"}
 
   @spec validate_event_id_seed(any) :: return
   defp validate_event_id_seed(event_id_seed) do

--- a/test/events/event_test.exs
+++ b/test/events/event_test.exs
@@ -69,18 +69,11 @@ defmodule ElixirTools.Events.EventTest do
                {:error, "Expected a number for the fix, but received 1.1.1a"}
     end
 
-    test "returns error when name does not contain an underscore", context do
-      event = %{context.valid_event | name: "EVENT"}
-
-      assert Event.publish(event, FakeAdapterSuccess) ==
-               {:error, "Expected an underscore in the event name, but got EVENT instead"}
-    end
-
     test "returns error when name is not a string", context do
       event = %{context.valid_event | name: :EVENT}
 
       assert Event.publish(event, FakeAdapterSuccess) ==
-               {:error, "Expected a string as event name, but got :EVENT"}
+               {:error, "Expected a string as event name, got :EVENT"}
     end
 
     test "returns error when they payload is not a map", context do


### PR DESCRIPTION
#### :tophat: Problem
We have obligatory `_` in event name. But `CHARGEBACK` event, for example, doesn't have any `_`
#### :pushpin: Solution
Remove this check

#### :ghost: GIF
 ![](https://media.giphy.com/media/HjlKKc14d5tBK/giphy.gif)
