### PR TITLE
Use Jason instead of Poison in ex_aws

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,7 @@ use Mix.Config
 #
 
 config :ex_aws, :sns, region: System.get_env("AWS_DEFAULT_REGION")
+config :ex_aws, json_codec: Jason
 
 config :pagantis_elixir_tools, ElixirTools.Metrix,
   default_tags: %{},


### PR DESCRIPTION
#### :tophat: Problem
We use default `Poison` in `ex_aws` but it's not in pg-elixir-tools deps. So if a parent project doesn't have this dependency - events cant be published with this message
```
{"reason":"%UndefinedFunctionError{arity: 1, function: :decode, message: nil, module: Poison, reason: nil}","version":"1.0.0"}
```
#### :pushpin: Solution
Switch to `Jason` - our default library

blocks https://github.com/digitalorigin/pg-bins/pull/36

#### :ghost: GIF
 ![](https://media.giphy.com/media/UdcdIGH8LVCHm/giphy.gif)
