### PR TITLE
in EventHandlerFake if version was not set use 1.0.0

### DIFF
--- a/lib/test_helper/event_handler_fake.ex
+++ b/lib/test_helper/event_handler_fake.ex
@@ -26,7 +26,7 @@ defmodule ElixirTools.TestHelper.EventHandlerFake do
       event_id_seed: event_id_seed,
       event_id_seed_optional: optional_params[:event_id_seed_optional],
       occurred_at: optional_params[:occurred_at],
-      version: optional_params[:version]
+      version: optional_params[:version] || "1.0.0"
     }
   end
 end

--- a/test/test_helper/event_handler_fake_test.exs
+++ b/test/test_helper/event_handler_fake_test.exs
@@ -43,7 +43,7 @@ defmodule ElixirTools.TestHelper.EventHandlerFakeTest do
                        ["event_name", "payload", "event_id_seed", ^optional_params]}
     end
 
-    test "if version was not set use 1.0.0" do
+    test "if version was not set, use 1.0.0" do
       optional_params = %{occurred_at: "occurred_at"}
       event = EventHandlerFake.create("event_name", "payload", "event_id_seed", optional_params)
       assert event.version == "1.0.0"

--- a/test/test_helper/event_handler_fake_test.exs
+++ b/test/test_helper/event_handler_fake_test.exs
@@ -42,5 +42,11 @@ defmodule ElixirTools.TestHelper.EventHandlerFakeTest do
       assert_received {:create_event,
                        ["event_name", "payload", "event_id_seed", ^optional_params]}
     end
+
+    test "if version was not set use 1.0.0" do
+      optional_params = %{occurred_at: "occurred_at"}
+      event = EventHandlerFake.create("event_name", "payload", "event_id_seed", optional_params)
+      assert event.version == "1.0.0"
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: Problem
EventHandlerFake behaviour is a bit different from EventHandler
#### :pushpin: Solution
They should have the same behaviour
#### :ghost: GIF
 ![](add_me)
