### PR TITLE
Fix the issue with .all

### DIFF
--- a/lib/schema/schema.ex
+++ b/lib/schema/schema.ex
@@ -124,7 +124,7 @@ defmodule ElixirTools.Schema do
       def last(field, value), do: Schema.SchemaImpl.last(__MODULE__, field, value)
 
       @doc """
-      Fetches all records from the DB.
+      Gets all entities based on query. If no query is given, all entities are returned.
       """
       @spec all(list) :: [t]
       def all(queryable \\ []), do: Schema.SchemaImpl.all(__MODULE__, queryable)

--- a/lib/schema/schema_impl.ex
+++ b/lib/schema/schema_impl.ex
@@ -143,7 +143,7 @@ defmodule ElixirTools.Schema.SchemaImpl do
   Fetches all records from the DB.
   """
   @spec all(ecto_schema, list) :: [t]
-  def all(module, queryable), do: module.repo.all(module, queryable)
+  def all(module, queryable), do: module.repo.all(queryable || module)
 
   @doc """
   Preloads a field on a struct.

--- a/lib/schema/schema_impl.ex
+++ b/lib/schema/schema_impl.ex
@@ -140,7 +140,7 @@ defmodule ElixirTools.Schema.SchemaImpl do
   def get_by!(module, queryable), do: module.repo.get_by!(module, queryable)
 
   @doc """
-  Fetches all records from the DB.
+  Gets all entities based on query. If no query is given, all entities are returned.
   """
   @spec all(ecto_schema, list) :: [t]
   def all(module, queryable), do: module.repo.all(queryable || module)

--- a/test/schema/schema_test.exs
+++ b/test/schema/schema_test.exs
@@ -1,5 +1,8 @@
 defmodule ElixirTools.SchemaTest do
   use ExUnit.Case, async: true
+
+  import Ecto.Query
+
   alias ElixirTools.Schema
   alias Support.{TestSchema, UniqueConstraintTestSchema}
 
@@ -320,7 +323,13 @@ defmodule ElixirTools.SchemaTest do
 
   describe "all/1" do
     test "returns a list of records based on the query" do
-      assert TestSchema.all(test_field_1: "dummy") == [%TestSchema{test_field_1: "dummy"}]
+      expected = [%TestSchema{test_field_1: "dummy"}]
+      assert TestSchema.all(from(o in TestSchema, where: o.something == ^1)) == expected
+    end
+
+    test "when passing the entity itself" do
+      expected = [%TestSchema{}, %TestSchema{}]
+      assert TestSchema.all(TestSchema) == expected
     end
   end
 end

--- a/test/support/test_repo.ex
+++ b/test/support/test_repo.ex
@@ -31,6 +31,6 @@ defmodule Support.TestRepo do
 
   @spec all(any) :: [TestSchema.t()]
   def all(queryable \\ [])
-  def all(test_field_1: "dummy"), do: [%TestSchema{test_field_1: "dummy"}]
+  def all(%Ecto.Query{}), do: [%TestSchema{test_field_1: "dummy"}]
   def all(_), do: [%TestSchema{}, %TestSchema{}]
 end

--- a/test/support/test_repo.ex
+++ b/test/support/test_repo.ex
@@ -29,8 +29,8 @@ defmodule Support.TestRepo do
   @spec one(any) :: Support.TestSchema.t()
   def one(_), do: %TestSchema{id: "existing"}
 
-  @spec all(any, Keyword.t()) :: [TestSchema.t()]
-  def all(module, queryable \\ [])
-  def all(_, test_field_1: "dummy"), do: [%TestSchema{test_field_1: "dummy"}]
-  def all(_, _), do: [%TestSchema{}, %TestSchema{}]
+  @spec all(any) :: [TestSchema.t()]
+  def all(queryable \\ [])
+  def all(test_field_1: "dummy"), do: [%TestSchema{test_field_1: "dummy"}]
+  def all(_), do: [%TestSchema{}, %TestSchema{}]
 end


### PR DESCRIPTION
#### :tophat: Problem
The .all was not implemented consistent with the ecto library due to a bug

#### :pushpin: Solution
Fix the bug. Since we are dependent on the ecto contract here instead of a real repo, I am added the ecto vs schema testing here:

```elixir
iex(8)> Operation.all(x) |> length
[debug] QUERY OK source="operations" db=6.5ms idle=9899.2ms
SELECT o0."id", o0."mc_processing_code", o0."amount", o0."type", o0."external_identifier", o0."merchant_type", o0."merchant_name", o0."merchant_city", o0."merchant_country_code", o0."merchant_category_name", o0."merchant_category", o0."card_id", o0."account_id", o0."inserted_at", o0."updated_at" FROM "operations" AS o0 WHERE (o0."amount" = $1) [1]
4
iex(9)> Operation.repo.all(from(op in Operation, where: op.amount == ^1)) |> length
[debug] QUERY OK source="operations" db=6.9ms idle=9929.3ms
SELECT o0."id", o0."mc_processing_code", o0."amount", o0."type", o0."external_identifier", o0."merchant_type", o0."merchant_name", o0."merchant_city", o0."merchant_country_code", o0."merchant_category_name", o0."merchant_category", o0."card_id", o0."account_id", o0."inserted_at", o0."updated_at" FROM "operations" AS o0 WHERE (o0."amount" = $1) [1]
4
iex(10)> Operation.all(Operation) |> length()                                       
[debug] QUERY OK source="operations" db=7.5ms queue=3.7ms idle=9952.7ms
SELECT o0."id", o0."mc_processing_code", o0."amount", o0."type", o0."external_identifier", o0."merchant_type", o0."merchant_name", o0."merchant_city", o0."merchant_country_code", o0."merchant_category_name", o0."merchant_category", o0."card_id", o0."account_id", o0."inserted_at", o0."updated_at" FROM "operations" AS o0 []
153
iex(11)> Operation.repo.all(Operation) |> length                                    
[debug] QUERY OK source="operations" db=9.8ms idle=9952.1ms
SELECT o0."id", o0."mc_processing_code", o0."amount", o0."type", o0."external_identifier", o0."merchant_type", o0."merchant_name", o0."merchant_city", o0."merchant_country_code", o0."merchant_category_name", o0."merchant_category", o0."card_id", o0."account_id", o0."inserted_at", o0."updated_at" FROM "operations" AS o0 []
153
```

#### :ghost: GIF
 ![](https://media.giphy.com/media/jpbGmSdR2j0uxlOQez/giphy.gif)
