### PR TITLE
PAYM-2893 Event JSON schema validation

### DIFF
--- a/lib/events/event.ex
+++ b/lib/events/event.ex
@@ -75,7 +75,7 @@ defmodule ElixirTools.Events.Event do
     end
   end
 
-  @spec validate_json_schema(Event.t(), event_schema) :: return
+  @spec validate_json_schema(map, event_schema) :: return
   def validate_json_schema(event, schema) do
     stringified_keys_event = to_string_keys(event)
 
@@ -85,7 +85,7 @@ defmodule ElixirTools.Events.Event do
     end
   end
 
-  @spec to_string_keys(Event.t()) :: map
+  @spec to_string_keys(map) :: map
   defp to_string_keys(event), do: event |> Jason.encode!() |> Jason.decode!()
 
   @spec validate_occurred_at(any) :: return

--- a/lib/events/event_handler.ex
+++ b/lib/events/event_handler.ex
@@ -71,7 +71,7 @@ defmodule ElixirTools.Events.EventHandler do
   end
 
   @spec publish_event_call(Event.t(), [events_opt]) :: :ok | :error
-  def publish_event_call(event, opts) do
+  defp publish_event_call(event, opts) do
     event_module = opts[:event_module] || Event
 
     case event_module.publish_deprecated(event) do

--- a/lib/events/event_handler.ex
+++ b/lib/events/event_handler.ex
@@ -61,14 +61,10 @@ defmodule ElixirTools.Events.EventHandler do
 
   @spec publish(Event.t(), event_schema, [events_opt]) :: :ok
   def publish(event, schema, opts) do
-    event_module = opts[:event_module] || Event
     task_supervisor_module = opts[:task_supervisor_module] || Task.Supervisor
 
     task_supervisor_module.async_nolink(ElixirTools.TaskSupervisor, fn ->
-      case event_module.validate_json_schema(schema, event) do
-        :ok -> publish_event_call(event, opts)
-        {:error, reason} -> handle_error(event, reason, opts)
-      end
+      publish_event_call(event, schema, opts)
     end)
 
     :ok
@@ -78,7 +74,17 @@ defmodule ElixirTools.Events.EventHandler do
   def publish_event_call(event, opts) do
     event_module = opts[:event_module] || Event
 
-    case event_module.publish(event) do
+    case event_module.publish_deprecated(event) do
+      {:error, reason} -> handle_error(event, reason, opts)
+      _ -> :ok
+    end
+  end
+
+  @spec publish_event_call(Event.t(), event_schema, [events_opt]) :: :ok | :error
+  def publish_event_call(event, schema, opts) do
+    event_module = opts[:event_module] || Event
+
+    case event_module.publish(event, schema) do
       {:error, reason} -> handle_error(event, reason, opts)
       _ -> :ok
     end

--- a/lib/events/event_handler.ex
+++ b/lib/events/event_handler.ex
@@ -81,7 +81,7 @@ defmodule ElixirTools.Events.EventHandler do
   end
 
   @spec publish_event_call(Event.t(), event_schema, [events_opt]) :: :ok | :error
-  def publish_event_call(event, schema, opts) do
+  defp publish_event_call(event, schema, opts) do
     event_module = opts[:event_module] || Event
 
     case event_module.publish(event, schema) do

--- a/test/events/fixtures/json_schemas/json_schema.json
+++ b/test/events/fixtures/json_schemas/json_schema.json
@@ -5,42 +5,42 @@
     "title": "The Root Schema",
     "description": "The root schema comprises the entire JSON document.",
     "required": [
-        "event_id_seed",
-        "event_id_seed_optional",
-        "name",
+        "id",
+        "action",
+        "group",
         "occurred_at",
         "payload",
         "version"
     ],
     "properties": {
-        "event_id_seed": {
-            "id": "#/properties/event_id_seed",
+        "id": {
+            "id": "#/properties/id",
             "type": "string",
-            "title": "The Event_id_seed Schema",
+            "title": "The Id Schema",
             "description": "An explanation about the purpose of this instance.",
             "default": "",
             "examples": [
                 "22833003-fb25-4961-8373-f01da28ec820"
             ]
         },
-        "event_id_seed_optional": {
-            "id": "#/properties/event_id_seed_optional",
+        "action": {
+            "id": "#/properties/action",
             "type": "string",
-            "title": "The Event_id_seed_optional Schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": "",
-            "examples": [
-                ""
-            ]
-        },
-        "name": {
-            "id": "#/properties/name",
-            "type": "string",
-            "title": "The Name Schema",
+            "title": "The Action Schema",
             "description": "An explanation about the purpose of this instance.",
             "default": "",
             "examples": [
                 "CHARGE_CREATED"
+            ]
+        },
+        "group": {
+            "id": "#/properties/group",
+            "type": "string",
+            "title": "The Group Schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": "",
+            "examples": [
+                "EVENT_GROUP"
             ]
         },
         "occurred_at": {


### PR DESCRIPTION
#### :tophat: Problem
JSON schema validation needs to be done.

#### :pushpin: Solution
Provide alternative flow detached from current one, to make sure backwards compatibility is provided in the migration to the new flow.

#### :ghost: GIF
![giphy](https://user-images.githubusercontent.com/2565201/78659933-7df39b80-78cc-11ea-8b9a-f70dcd556171.gif)

