### PR TITLE
Stop sending request_path in plug

### DIFF
--- a/lib/metrix/plug.ex
+++ b/lib/metrix/plug.ex
@@ -41,7 +41,6 @@ defmodule ElixirTools.Metrix.Plug do
       controller: Tags.controller_name(conn),
       action: Tags.method_name(conn),
       http_method: conn.method,
-      request_path: Tags.request_path(conn),
       api_version: Tags.api_version(conn),
       response_status_code: conn.status,
       response_status_code_class: Tags.response_status_code_class(conn)

--- a/test/metrix/plug_test.exs
+++ b/test/metrix/plug_test.exs
@@ -86,7 +86,6 @@ defmodule ElixirTools.Metrix.PlugTest do
         api_version: "v1",
         controller: "MyController",
         http_method: "GET",
-        request_path: "/v1/my_controller",
         response_status_code: 200,
         response_status_code_class: "2xx"
       }


### PR DESCRIPTION
#### :tophat: Problem
We want to avoid generating new custom metrics per path (in this case we generate thousands of them, pay a lot and not really use them later)
#### :pushpin: Solution
Stop sending request path
#### :ghost: GIF
 ![](https://media.giphy.com/media/bM0ReSPKaLfHO/giphy.gif)
