### PR TITLE
Remove rollbax dependency

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -14,5 +14,3 @@ config :pagantis_elixir_tools, ElixirTools.Events, adapter_config: %{group: "EVE
 config :pagantis_elixir_tools, ElixirTools.Schema, default_repo: Support.TestRepo
 
 config :pagantis_elixir_tools, ElixirTools.HttpClient, response_timeout: 1500
-
-config :rollbax, enabled: false

--- a/lib/test_helper/rollbax_fake.ex
+++ b/lib/test_helper/rollbax_fake.ex
@@ -1,14 +1,10 @@
 defmodule ElixirTools.RollbaxFake do
-  use ElixirTools.ContractImpl, module: Rollbax
-
-  @impl true
   def report_message(level, message, custom \\ %{}, occurrence_data \\ %{}) do
     ensure_no_struct(custom)
     ensure_no_struct(occurrence_data)
     send(self(), [:rollbax_message, level, message, custom, occurrence_data])
   end
 
-  @impl true
   def report(kind, value, stacktrace, custom \\ %{}, occurrence_data \\ %{}) do
     ensure_no_struct(custom)
     ensure_no_struct(occurrence_data)

--- a/lib/test_helper/rollbax_fake.ex
+++ b/lib/test_helper/rollbax_fake.ex
@@ -1,16 +1,20 @@
 defmodule ElixirTools.RollbaxFake do
+  @spec report_message(:critical | :error | :warning | :info | :debug, IO.chardata(), map, map) ::
+          :ok
   def report_message(level, message, custom \\ %{}, occurrence_data \\ %{}) do
     ensure_no_struct(custom)
     ensure_no_struct(occurrence_data)
     send(self(), [:rollbax_message, level, message, custom, occurrence_data])
   end
 
+  @spec report(:error | :exit | :throw, any, [any], map, map) :: :ok
   def report(kind, value, stacktrace, custom \\ %{}, occurrence_data \\ %{}) do
     ensure_no_struct(custom)
     ensure_no_struct(occurrence_data)
     send(self(), [:rollbax_report, kind, value, stacktrace, custom, occurrence_data])
   end
 
+  @spec ensure_no_struct(any) :: no_return() | :ok
   defp ensure_no_struct(map) when is_struct(map) do
     raise "Rollbax does not know how to handle structs and will raise an error. Convert it to a map."
   end

--- a/mix.exs
+++ b/mix.exs
@@ -54,8 +54,7 @@ defmodule ElixirTools.MixProject do
       {:ja_serializer, "~> 0.14"},
       {:ecto_sql, "~> 3.0"},
       {:statix, ">= 0.0.0"},
-      {:httpoison, "~> 1.4"},
-      {:rollbax, ">= 0.0.0"}
+      {:httpoison, "~> 1.4"}
     ]
   end
 


### PR DESCRIPTION
#### :tophat: Problem
We have rollbar as a dependency in elixir tools just to support the contractimpl and it's causing problems in projects that don't have configuration for it.

#### :pushpin: Solution
Remove it

#### :ghost: GIF
 ![](https://media.giphy.com/media/64de3Bfw072AU/giphy.gif)
