### PR TITLE
Make EventHandler.publish_event_call public

### DIFF
--- a/lib/events/event_handler.ex
+++ b/lib/events/event_handler.ex
@@ -71,7 +71,7 @@ defmodule ElixirTools.Events.EventHandler do
   end
 
   @spec publish_event_call(Event.t(), [events_opt]) :: :ok | :error
-  defp publish_event_call(event, opts) do
+  def publish_event_call(event, opts) do
     event_module = opts[:event_module] || Event
 
     case event_module.publish_deprecated(event) do
@@ -81,7 +81,7 @@ defmodule ElixirTools.Events.EventHandler do
   end
 
   @spec publish_event_call(Event.t(), event_schema, [events_opt]) :: :ok | :error
-  defp publish_event_call(event, schema, opts) do
+  def publish_event_call(event, schema, opts) do
     event_module = opts[:event_module] || Event
 
     case event_module.publish(event, schema) do

--- a/test/events/event_handler_test.exs
+++ b/test/events/event_handler_test.exs
@@ -139,6 +139,44 @@ defmodule ElixirTools.Events.EventHandlerTest do
     end
   end
 
+  describe "publish_event_call/2" do
+    test "event is published as expected", %{event: event} do
+      opts = [{:event_module, EventDeprecatedFakeOk}]
+      assert EventHandler.publish_event_call(event, opts) == :ok
+      assert_received({:publish, ^event})
+    end
+
+    test "event publishing call returns error", %{event: event} do
+      opts = [
+        {:task_supervisor_module, TaskSupervisorFake},
+        {:event_module, EventDeprecatedFakeFail},
+        {:telemetry_module, TelemetryFake}
+      ]
+
+      assert EventHandler.publish_event_call(event, opts) == :error
+      assert_received({:publish, ^event})
+    end
+  end
+
+  describe "publish_event_call/3" do
+    test "event is published as expected", %{event: event, schema: schema} do
+      opts = [{:event_module, EventFakeOk}]
+      assert EventHandler.publish_event_call(event, schema, opts) == :ok
+      assert_received({:publish, [^event, ^schema]})
+    end
+
+    test "event publishing call returns error", %{event: event, schema: schema} do
+      opts = [
+        {:task_supervisor_module, TaskSupervisorFake},
+        {:event_module, EventFakeFail},
+        {:telemetry_module, TelemetryFake}
+      ]
+
+      assert EventHandler.publish_event_call(event, schema, opts) == :error
+      assert_received({:publish, [^event, ^schema]})
+    end
+  end
+
   describe "publish/2" do
     test "event is published as expected", %{event: event} do
       opts = [


### PR DESCRIPTION
#### :tophat: Problem
We need to be able to publish events synchronously. We had this possibility before
#### :pushpin: Solution
Make `EventHandler.publish_event_call` public again
#### :ghost: GIF
 ![](https://media.giphy.com/media/APy9AGi0BWNJQhIULv/giphy.gif)
