### PR TITLE
Add publish_event_call to event_handler_fake

### DIFF
--- a/lib/test_helper/event_handler_fake.ex
+++ b/lib/test_helper/event_handler_fake.ex
@@ -16,6 +16,18 @@ defmodule ElixirTools.TestHelper.EventHandlerFake do
   end
 
   @impl true
+  def publish_event_call(event, _) do
+    send(self(), {:publish_event_call, event})
+    :ok
+  end
+
+  @impl true
+  def publish_event_call(event, schema, _) do
+    send(self(), {:publish_event_call, [event, schema]})
+    :ok
+  end
+
+  @impl true
   def create(event_name, payload, event_id_seed) do
     send(self(), {:create_event, [event_name, payload, event_id_seed]})
     %Event{name: event_name, payload: payload, event_id_seed: event_id_seed}

--- a/test/test_helper/event_handler_fake_test.exs
+++ b/test/test_helper/event_handler_fake_test.exs
@@ -18,6 +18,20 @@ defmodule ElixirTools.TestHelper.EventHandlerFakeTest do
     end
   end
 
+  describe "publish_event_call/2" do
+    test "returns expected value and sends expected message" do
+      assert EventHandlerFake.publish_event_call("event", "opts") == :ok
+      assert_received {:publish_event_call, "event"}
+    end
+  end
+
+  describe "publish_event_call/3" do
+    test "returns expected value and sends expected message" do
+      assert EventHandlerFake.publish_event_call("event", "schema", "opts") == :ok
+      assert_received {:publish_event_call, ["event", "schema"]}
+    end
+  end
+
   describe "create/3" do
     test "returns expected value and sends expected message" do
       event = %Event{name: "event_name", payload: "payload", event_id_seed: "event_id_seed"}


### PR DESCRIPTION
#### :tophat: Problem
We have a rarely used method `publish_event_call` for sync events sending. We want to use it in code - but we cant test it because it's not implemented in `EventHandlerFake` 
#### :pushpin: Solution
add it to ` `EventHandlerFake` 
#### :ghost: GIF
 ![](https://media.giphy.com/media/39hoXKE2isn6nrwKos/giphy.gif)
