### PR TITLE
Allow setting default headers per adapter

### DIFF
--- a/lib/http_client/README.md
+++ b/lib/http_client/README.md
@@ -14,9 +14,10 @@ config :pagantis_elixir_tools, ElixirTools.HttpClient,
 ```
 
 ## Usage
-Client has to create `adapter` for a specific provider with implemented function `base_uri()`. 
 
-This module should use `@behaviour ElixirTools.HttpClient.Adapter`
+Client has to create `adapter` for a specific provider with implemented function `base_uri()`.
+
+This module should use `use ElixirTools.HttpClient.Adapter`
 
 To do http request you add to your code the following code
 

--- a/lib/http_client/adapter.ex
+++ b/lib/http_client/adapter.ex
@@ -7,4 +7,23 @@ defmodule ElixirTools.HttpClient.Adapter do
   Returns the base URI String for the HTTP endpoint of a specific adapter.
   """
   @callback base_uri() :: String.t()
+
+  @doc """
+  Returns the token for a specific request.
+  """
+  @callback default_headers() :: String.t()
+
+  @optional_callbacks [default_headers: 0]
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour ElixirTools.HttpClient.Adapter
+
+      @impl true
+      @spec default_headers :: [tuple]
+      def default_headers, do: []
+
+      defoverridable default_headers: 0
+    end
+  end
 end

--- a/lib/http_client/adapter.ex
+++ b/lib/http_client/adapter.ex
@@ -11,7 +11,7 @@ defmodule ElixirTools.HttpClient.Adapter do
   @doc """
   Returns the token for a specific request.
   """
-  @callback default_headers() :: String.t()
+  @callback default_headers() :: [tuple]
 
   @optional_callbacks [default_headers: 0]
 

--- a/lib/http_client/http_client.ex
+++ b/lib/http_client/http_client.ex
@@ -18,7 +18,7 @@ defmodule ElixirTools.HttpClient do
   @type request_body :: String.t()
   @type response_body :: HTTPoison.Response.t()
   @type header :: {String.t(), String.t()}
-  @type uri :: URI.t()
+  @type uri :: String.t()
   @type base_uri :: String.t()
   @type action :: :get | :create | :update
   @type adapter :: module

--- a/lib/http_client/http_client.ex
+++ b/lib/http_client/http_client.ex
@@ -34,7 +34,7 @@ defmodule ElixirTools.HttpClient do
       http_client.post(uri, request_body, headers, connection_options)
     end
 
-    do_request(post_request, opts)
+    do_request(adapter, post_request, opts)
   end
 
   @spec put(adapter, path, request_body, [put_opt]) :: {:ok, response_body} | {:error, term}
@@ -46,7 +46,7 @@ defmodule ElixirTools.HttpClient do
       http_client.put(uri, request_body, headers, connection_options)
     end
 
-    do_request(put_request, opts)
+    do_request(adapter, put_request, opts)
   end
 
   @spec get(adapter, path, [post_opt]) :: {:ok, response_body} | {:error, term}
@@ -58,13 +58,13 @@ defmodule ElixirTools.HttpClient do
       http_client.get(uri, headers, connection_options)
     end
 
-    do_request(get_request, opts)
+    do_request(adapter, get_request, opts)
   end
 
   @spec build_uri(base_uri, path) :: uri | no_return
   defp build_uri(base_uri, path) do
     adapter_base_uri = ensure_valid_uri!(base_uri)
-    URI.merge(adapter_base_uri, path)
+    Path.join(adapter_base_uri, path)
   end
 
   @spec ensure_valid_uri!(term) :: term | no_return
@@ -74,11 +74,11 @@ defmodule ElixirTools.HttpClient do
 
   defp ensure_valid_uri!(uri), do: uri
 
-  @spec do_request(fun(), [post_opt]) :: {:ok, response_body} | {:error, term}
-  defp do_request(request, opts) do
+  @spec do_request(adapter, fun(), [post_opt]) :: {:ok, response_body} | {:error, term}
+  defp do_request(adapter, request, opts) do
     headers_to_add = opts[:headers_to_add] || []
-    headers = opts[:headers] || default_headers()
-    headers = headers_to_add ++ headers
+    default_headers = opts[:headers] || adapter.default_headers()
+    headers = headers_to_add ++ default_headers
 
     connection_options = default_connection_options()
 
@@ -93,7 +93,7 @@ defmodule ElixirTools.HttpClient do
         if opts[:retry_closed] do
           response
         else
-          do_request(request, [{:retry_closed, true} | opts])
+          do_request(adapter, request, [{:retry_closed, true} | opts])
         end
 
       {:error, %HTTPoison.Error{}} = error_response ->
@@ -113,13 +113,6 @@ defmodule ElixirTools.HttpClient do
       {:error, _} ->
         raise "Invalid JSON returned from provider. Given: #{inspect(response.body)}"
     end
-  end
-
-  @spec default_headers :: [header]
-  defp default_headers() do
-    [
-      {"Content-Type", "application/json"}
-    ]
   end
 
   @spec http_client() :: module


### PR DESCRIPTION
#### :tophat: Problem
Often you have custom headers that have to be sent in the request. An example can be a token. Since they are different per provider, they need to be set on the adapter themself.

#### :pushpin: Solution
Set the headers using an overridable function `default_headers`. This PR also brings some changes to how URLS are interpreted, which was a bug. As both changes need to be deployed together, I added them to the same PR.

PS: This is a breaking change. 

#### :ghost: GIF
 ![](https://media.giphy.com/media/L4UFnRv6gSav8N41Yj/giphy.gif)
